### PR TITLE
Fixed the View to fix the Navigation View

### DIFF
--- a/app/src/main/res/layout/activity_corridor_navigation.xml
+++ b/app/src/main/res/layout/activity_corridor_navigation.xml
@@ -24,13 +24,15 @@
 
     <com.mapbox.services.android.navigation.ui.v5.NavigationView
         android:id="@+id/navigationView"
-        app:navigationLightTheme="@style/CustomNavigationViewLight"
-        app:navigationDarkTheme="@style/CustomNavigationViewLight"
-        android:layout_width="638dp"
+        android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="1.0"
+        app:navigationDarkTheme="@style/CustomNavigationViewLight"
+        app:navigationLightTheme="@style/CustomNavigationViewLight"
         mapbox:mapbox_cameraTargetLat="52.520008"
         mapbox:mapbox_cameraTargetLng="13.404954"
         mapbox:mapbox_cameraZoom="12"


### PR DESCRIPTION
To fix the Navigation Zoom it was necessary to fix the layout, correcting the layout resulted in the navigation hints being scaled correctly as well.